### PR TITLE
[Hotfix] 저장지원view UI수정

### DIFF
--- a/janghakhere/janghakhere/Data/Actor/MyScholarshipBoxListActor.swift
+++ b/janghakhere/janghakhere/Data/Actor/MyScholarshipBoxListActor.swift
@@ -37,7 +37,6 @@ actor MyScholarshipBoxListActor {
             
             let scholarshipList = try responseHandling(data, response)
             
-            print("scholarshipList", scholarshipList)
             return scholarshipList
         } catch {
             throw error

--- a/janghakhere/janghakhere/Data/Actor/ScholarshipStatusActor.swift
+++ b/janghakhere/janghakhere/Data/Actor/ScholarshipStatusActor.swift
@@ -25,7 +25,7 @@ actor ScholarshipStatusActor {
             
             switch response.statusCode {
             case 200:
-                print("성공")
+                break
             default: // 기술적 문제
                 throw URLError(.badServerResponse)
             }
@@ -43,7 +43,7 @@ actor ScholarshipStatusActor {
             
             switch response.statusCode {
             case 200:
-                print("성공")
+                break
             default: // 기술적 문제
                 throw URLError(.badServerResponse)
             }

--- a/janghakhere/janghakhere/Data/Actor/ScholarshipStatusActor.swift
+++ b/janghakhere/janghakhere/Data/Actor/ScholarshipStatusActor.swift
@@ -15,7 +15,7 @@ actor ScholarshipStatusActor {
     }
     
     // 장학금 지원 status 추가/수정
-    func postScholarshipStatus(id: String, status: String) async throws -> Bool {
+    func postScholarshipStatus(id: String, status: String) async throws {
         do {
             let postStruct = scholarship(id: id, status: status)
             
@@ -26,7 +26,6 @@ actor ScholarshipStatusActor {
             switch response.statusCode {
             case 200:
                 print("성공")
-                return true
             default: // 기술적 문제
                 throw URLError(.badServerResponse)
             }
@@ -36,7 +35,7 @@ actor ScholarshipStatusActor {
     }
     
     // 장학금 지원 status 삭제
-    func deleteScholarshipStatus(id: String) async throws -> Bool {
+    func deleteScholarshipStatus(id: String) async throws {
         do {
             guard let userID = UserDateActor.getUserID() else { throw URLError(.unknown) }
             
@@ -45,7 +44,6 @@ actor ScholarshipStatusActor {
             switch response.statusCode {
             case 200:
                 print("성공")
-                return true
             default: // 기술적 문제
                 throw URLError(.badServerResponse)
             }

--- a/janghakhere/janghakhere/Feature/AllScholarship/AllScholarshipView.swift
+++ b/janghakhere/janghakhere/Feature/AllScholarship/AllScholarshipView.swift
@@ -32,7 +32,7 @@ struct AllScholarshipView: View {
                         if viewModel.scholarshipCategory == .custom && viewModel.scholarshipList.isEmpty {
                             emptyCustomScholarshipView(proxy: proxy)
                         } else {
-                            ScholarshipBoxListView(isGetMoreScholarshipBox: $viewModel.isGetMoreScholarshipBox, scholarshipList: $viewModel.scholarshipList, boxCategory: .AllScholarship, isShowPassStatus: false)
+                            ScholarshipBoxListView(isGetMoreScholarshipBox: $viewModel.isGetMoreScholarshipBox, scholarshipList: $viewModel.scholarshipList, boxCategory: .AllScholarship)
                                 .onChange(of: viewModel.isGetMoreScholarshipBox, { _, _ in
                                     userTouchedBottomOfTheScroll()
                                 })

--- a/janghakhere/janghakhere/Feature/AllScholarship/AllScholarshipViewModel.swift
+++ b/janghakhere/janghakhere/Feature/AllScholarship/AllScholarshipViewModel.swift
@@ -29,6 +29,7 @@ final class AllScholarshipViewModel: ObservableObject {
     @Published var isGetMoreScholarshipBox = false
     @Published var filteringcategory: ScholarshipBoxListFliteringCategory = .allCases.first!
     @Published var isShowFilteringSheet = false
+    @Published var isShowError = false
     @Published var name: String = ""
     
     @Published private(set) var isNewAlarm: Bool = false

--- a/janghakhere/janghakhere/Feature/AllScholarship/Search/SearchScholarshipView.swift
+++ b/janghakhere/janghakhere/Feature/AllScholarship/Search/SearchScholarshipView.swift
@@ -25,7 +25,7 @@ struct SearchScholarshipView: View {
             case .loading:
                 loading()
             case .searchedWithData:
-                ScholarshipBoxListView(isGetMoreScholarshipBox: $isGetMoreScholarshipBox, scholarshipList: $viewModel.scholarshipList, boxCategory: .SearchScholarship, isShowPassStatus: false)
+                ScholarshipBoxListView(isGetMoreScholarshipBox: $isGetMoreScholarshipBox, scholarshipList: $viewModel.scholarshipList, boxCategory: .SearchScholarship)
                     .onChange(of: viewModel.isGetMoreScholarshipBox, { _, _ in
                         userTouchedBottomOfTheScroll()
                     })

--- a/janghakhere/janghakhere/Feature/ErrorToastView.swift
+++ b/janghakhere/janghakhere/Feature/ErrorToastView.swift
@@ -52,6 +52,7 @@ struct ErrorToastView: View {
                         isShowAlert = false
                     }
                 }
+                .frame(maxWidth: .infinity, alignment: .center)
             } else {
                 EmptyView()
             }

--- a/janghakhere/janghakhere/Feature/MyScholarship/MyScholarshipView.swift
+++ b/janghakhere/janghakhere/Feature/MyScholarship/MyScholarshipView.swift
@@ -26,11 +26,7 @@ struct MyScholarshipView: View {
                             Spacer()
                         }
                     case .success:
-                        if viewModel.totalScholarShipList.isEmpty {
-                            emptyView()
-                        } else {
                             detailScholarshipBoxListView()
-                        }
                     case .failed:
                         ZStack(alignment: .bottom) {
                             VStack(spacing: 0) {
@@ -189,10 +185,22 @@ extension MyScholarshipView {
     func detailScholarshipBoxListView() -> some View {
         //TODO: TabView
         VStack(spacing: 0) {
-            if viewModel.selectedCategoryName == MyScholarshipCategory.storedName {
-                ScholarshipBoxListView(isGetMoreScholarshipBox: .constant(false), scholarshipList: $viewModel.selectedScholarShipList, boxCategory: .DetailScholarship, isShowPassStatus: false)
+            if viewModel.selectedScholarShipList.isEmpty {
+                switch viewModel.selectedCategory {
+                case.stored(_):
+                    emptyView(title: "여깄장학과 함께 저장하고\n지원해보세요", content: "여깄장학과 함께 저장하고\n지원해보세요")
+                case.supported(let category):
+                    switch category {
+                    case .applied:
+                        emptyView(title: "아직 지원한 장학금이 없어요", content: "여깄장학과 함께 지원하고\n합격해보세요")
+                    case .passed:
+                        emptyView(title: "아직 합격한 장학금이 없어요", content: "여깄장학과 함께 지원하고\n합격해보세요")
+                    case .non_passed:
+                        emptyView(title: "불합격한 장학금이 없어요", content: nil)
+                    }
+                }
             } else {
-                ScholarshipBoxListView(isGetMoreScholarshipBox: .constant(false), scholarshipList: $viewModel.selectedScholarShipList, boxCategory: .SearchScholarship, isShowPassStatus: true)
+                ScholarshipBoxListView(isGetMoreScholarshipBox: .constant(false), scholarshipList: $viewModel.selectedScholarShipList, boxCategory: .MyScholarship)
             }
             Spacer()
         }
@@ -216,14 +224,20 @@ extension MyScholarshipView {
         }
     }
     @ViewBuilder
-    private func emptyView() -> some View {
+    private func emptyView(title: String, content: String?) -> some View {
         VStack(spacing: 8) {
             Spacer()
-            Icon(name: .nothing, size: 122)
-            Text("저장한 공고가 없어요\n지원하고 싶은 공고를 저장해보세요")
+            Icon(name: .grabPaper, color: .gray400, size: 122)
+            Text(title)
                 .multilineTextAlignment(.center)
-                .font(.text_md)
+                .font(.title_xsm)
                 .foregroundStyle(.gray600)
+            if let content {
+                Text(content)
+                    .multilineTextAlignment(.center)
+                    .font(.text_sm)
+                    .foregroundStyle(.gray600)
+            }
             Spacer()
         }
     }

--- a/janghakhere/janghakhere/Feature/MyScholarship/MyScholarshipView.swift
+++ b/janghakhere/janghakhere/Feature/MyScholarship/MyScholarshipView.swift
@@ -26,39 +26,9 @@ struct MyScholarshipView: View {
                             Spacer()
                         }
                     case .success:
-                            detailScholarshipBoxListView()
+                        detailScholarshipBoxListView()
                     case .failed:
-                        ZStack(alignment: .bottom) {
-                            VStack(spacing: 0) {
-                                Spacer()
-                                Button {
-                                    viewModel.reloadButtonPressed()
-                                } label: {
-                                    VStack(spacing: 0) {
-                                        Icon(name: .graduation, size: 122)
-                                            .padding(.bottom, 8)
-                                        Text("잠시 후에 다시 시도해주세요")
-                                            .font(.title_xsm)
-                                            .padding(.bottom, 16)
-                                            .foregroundStyle(.gray600)
-                                        HStack {
-                                            Icon(name: .reload, color: .mainGray, size: 22)
-                                                .padding(.leading, 8)
-                                            Text("새로 고침")
-                                                .foregroundStyle(.mainGray)
-                                        }
-                                        .padding(.vertical, 14)
-                                        .padding(.horizontal, 24)
-                                        .background(.gray70)
-                                        .cornerRadius(130)
-                                    }
-                                }
-                                Spacer()
-                            }
-                            ErrorToastView(.network)
-                        }
-                        .frame(maxWidth: .infinity)
-                        .background(Color.gray50)
+                        error()
                     }
                 }
             }
@@ -243,31 +213,65 @@ extension MyScholarshipView {
     }
     @ViewBuilder
     private func filteringSheet() -> some View {
-    VStack(alignment: .leading, spacing: 0) {
-        Text("정렬")
-            .font(.title_xsm)
-            .padding(.top, 20)
-            .frame(maxWidth: .infinity)
-        ForEach(MyScholarshipFilteringCategory.allCases, id: \.self) { category in
-            filteringButton(category: category)
-        }
-        Spacer()
-        Text("닫기")
-            .font(.title_xsm)
-            .foregroundStyle(.white)
-            .padding(.vertical, 16)
-            .frame(maxWidth: .infinity)
-            .background(.mainGray)
-            .cornerRadius(100)
-            .padding(.bottom, 14)
-            .onTapGesture {
-                viewModel.isShowFilteringSheet = false
+        VStack(alignment: .leading, spacing: 0) {
+            Text("정렬")
+                .font(.title_xsm)
+                .padding(.top, 20)
+                .frame(maxWidth: .infinity)
+            ForEach(MyScholarshipFilteringCategory.allCases, id: \.self) { category in
+                filteringButton(category: category)
             }
+            Spacer()
+            Text("닫기")
+                .font(.title_xsm)
+                .foregroundStyle(.white)
+                .padding(.vertical, 16)
+                .frame(maxWidth: .infinity)
+                .background(.mainGray)
+                .cornerRadius(100)
+                .padding(.bottom, 14)
+                .onTapGesture {
+                    viewModel.isShowFilteringSheet = false
+                }
+        }
+        .padding(.horizontal, 28)
+        .foregroundStyle(.black)
+        .presentationDetents([.medium])
     }
-    .padding(.horizontal, 28)
-    .foregroundStyle(.black)
-    .presentationDetents([.medium])
-}
+    @ViewBuilder
+    private func error() -> some View {
+        ZStack(alignment: .bottom) {
+            VStack(spacing: 0) {
+                Spacer()
+                Button {
+                    viewModel.reloadButtonPressed()
+                } label: {
+                    VStack(spacing: 0) {
+                        Icon(name: .graduation, size: 122)
+                            .padding(.bottom, 8)
+                        Text("잠시 후에 다시 시도해주세요")
+                            .font(.title_xsm)
+                            .padding(.bottom, 16)
+                            .foregroundStyle(.gray600)
+                        HStack {
+                            Icon(name: .reload, color: .mainGray, size: 22)
+                                .padding(.leading, 8)
+                            Text("새로 고침")
+                                .foregroundStyle(.mainGray)
+                        }
+                        .padding(.vertical, 14)
+                        .padding(.horizontal, 24)
+                        .background(.gray70)
+                        .cornerRadius(130)
+                    }
+                }
+                Spacer()
+            }
+            ErrorToastView(.network)
+        }
+        .frame(maxWidth: .infinity)
+        .background(Color.gray50)
+    }
 }
 
 #Preview {

--- a/janghakhere/janghakhere/Feature/MyScholarship/MyScholarshipViewModel.swift
+++ b/janghakhere/janghakhere/Feature/MyScholarship/MyScholarshipViewModel.swift
@@ -91,7 +91,7 @@ extension MyScholarshipViewModel {
                 selectedScholarShipList = totalScholarShipList.filter({ $0.publicAnnouncementStatus == .passed })
             }
         case .stored(let storedCategory):
-            let filterScholarShipList = totalScholarShipList.filter({ $0.publicAnnouncementStatus != .non_passed && $0.publicAnnouncementStatus != .passed && $0.publicAnnouncementStatus != .nothing})
+            let filterScholarShipList = totalScholarShipList.filter({ $0.publicAnnouncementStatus != .nothing})
             switch storedCategory {
             case .all:
                 selectedScholarShipList = filterScholarShipList

--- a/janghakhere/janghakhere/Feature/MyScholarship/MyScholarshipViewModel.swift
+++ b/janghakhere/janghakhere/Feature/MyScholarship/MyScholarshipViewModel.swift
@@ -14,6 +14,7 @@ final class MyScholarshipViewModel: ObservableObject {
     @Published private(set) var selectedCategory: MyScholarshipCategory = .stored(.all)
     @Published private(set) var selectedCategoryName: String = MyScholarshipCategory.storedName
     @Published private(set) var selectedCategoryDetailName: String = StorageCategory.allCases.first?.name ?? "에베베"
+    @Published private(set) var selectedDetailCategory: PublicAnnouncementStatusCategory? = nil
     
     @Published private(set) var networkStatus: NetworkStatus = .loading
     @Published var filteringCategory: MyScholarshipFilteringCategory = .allCases.first!

--- a/janghakhere/janghakhere/Feature/MyScholarship/SuccessFailView.swift
+++ b/janghakhere/janghakhere/Feature/MyScholarship/SuccessFailView.swift
@@ -83,8 +83,11 @@ extension SuccessFailView {
             if !amount.isEmpty {
                 Text("완료")
                     .font(.title_xsm)
-                    .foregroundStyle(.gray600)
-                    .padding(.trailing, 16)
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 8)
+                    .background(Color.mainGray)
+                    .cornerRadius(4)
                     .onTapGesture {
                         passedFinishedButtonPressed()
                     }

--- a/janghakhere/janghakhere/Feature/MyScholarship/SuccessFailView.swift
+++ b/janghakhere/janghakhere/Feature/MyScholarship/SuccessFailView.swift
@@ -16,13 +16,27 @@ struct SuccessFailView: View {
     @State var amount: String = ""
     @State private var textRect = CGRect()
     
+    @State var isSelectedPass: selectedButton = .none
+    
+    let isChangedToPass: () -> Void
+    let isChangedToFailed: () -> Void
+    
+    enum selectedButton {
+        case pass
+        case failed
+        case none
+    }
+    
     @FocusState private var isKeyBoardOn: Bool
     
     let placeHolder: String = "0"
     
-    init(scholarshipBox: Binding<ScholarshipBox?>, isShowPassModal: Binding<Bool>) {
+    init(scholarshipBox: Binding<ScholarshipBox?>, isShowPassModal: Binding<Bool>,
+         isChangedToPass: @escaping () -> Void, isChangedToFailed: @escaping () -> Void) {
         self._scholarshipBox = scholarshipBox
         self._isShowPassModal = isShowPassModal
+        self.isChangedToPass = isChangedToPass
+        self.isChangedToFailed = isChangedToFailed
     }
     
     var body: some View {
@@ -37,16 +51,16 @@ struct SuccessFailView: View {
                 passButton()
                 failedButton()
                     .padding(.bottom, 60)
-                if scholarshipBox!.publicAnnouncementStatus == .passed {
+                if isSelectedPass == .pass {
                     passedAmmountTextField()
                 }
                 Spacer()
-                if !isKeyBoardOn {
-                    submitButton()
-                }
             }
         }
         .paddingHorizontal()
+        .onChange(of: scholarshipBox?.publicAnnouncementStatus) { _,_ in
+            print("scholarshipBox?.publicAnnouncementStatus 바뀜", scholarshipBox?.publicAnnouncementStatus)
+        }
     }
 }
 
@@ -89,7 +103,11 @@ extension SuccessFailView {
                     .background(Color.mainGray)
                     .cornerRadius(4)
                     .onTapGesture {
-                        passedFinishedButtonPressed()
+                        passedFinishedButtonPressed(success: {
+                            scholarshipBox!.publicAnnouncementStatus = .passed
+                            isShowPassModal = false
+                            isChangedToPass()
+                        })
                     }
             }
         }
@@ -100,7 +118,7 @@ extension SuccessFailView {
     @ViewBuilder
     private func passButton() -> some View {
         Button {
-            scholarshipBox!.publicAnnouncementStatus = .passed
+            isSelectedPass = .pass
         } label: {
             Text("합격")
                 .multilineTextAlignment(.leading)
@@ -108,8 +126,8 @@ extension SuccessFailView {
                 .padding(.leading, 24)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .font(.title_xsm)
-                .foregroundStyle( scholarshipBox!.publicAnnouncementStatus == .passed ? .white : .gray600)
-                .background( scholarshipBox!.publicAnnouncementStatus == .passed ? .subGreen : .gray70)
+                .foregroundStyle( isSelectedPass == .pass ? .white : .gray600)
+                .background( isSelectedPass == .pass ? .subGreen : .gray70)
                 .cornerRadius(4)
         }
         .padding(.bottom, 20)
@@ -118,35 +136,24 @@ extension SuccessFailView {
     @ViewBuilder
     private func failedButton() -> some View {
         Button {
-            failedFinishedButtonPressed()
+            isSelectedPass = .failed
+            failedFinishedButtonPressed {
+                scholarshipBox!.publicAnnouncementStatus = .non_passed
+                isShowPassModal = false
+                isChangedToFailed()
+            }
         } label: {
             Text("불합격")
                 .padding(.vertical, 20)
                 .padding(.leading, 24)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .font(.title_xsm)
-                .foregroundStyle( scholarshipBox!.publicAnnouncementStatus == .non_passed ? .white : .gray600)
-                .background( scholarshipBox!.publicAnnouncementStatus == .non_passed ? Color.ectRed : .gray70)
+                .foregroundStyle( isSelectedPass == .failed ? .white : .gray600)
+                .background( isSelectedPass == .failed ? Color.ectRed : .gray70)
                 .cornerRadius(4)
         }
     }
-    
-    @ViewBuilder
-    private func submitButton() -> some View {
-        Button {
-            passedFinishedButtonPressed()
-        } label: {
-            let isSubmitmode = scholarshipBox!.publicAnnouncementStatus == .non_passed || (scholarshipBox!.publicAnnouncementStatus == .passed && !amount.isEmpty)
-            Text("완료")
-                .padding(.vertical, 16)
-                .frame(maxWidth: .infinity)
-                .font(.title_xsm)
-                .foregroundStyle(isSubmitmode ? .white :.gray500)
-                .background( isSubmitmode ? .mainGray : .gray100)
-                .cornerRadius(100)
-                .padding(.bottom, 18)
-        }
-    }
+
     @ViewBuilder
     private func TextFieldDynamicWidth() -> some View {
         ZStack {
@@ -155,18 +162,6 @@ extension SuccessFailView {
                 TextField(text: $amount) {
                     Text(placeHolder)
                         .foregroundStyle(.gray300)
-                }
-                .toolbar {
-                    ToolbarItem(placement: .keyboard) {
-                        Spacer()
-                        Button {
-                            passedFinishedButtonPressed()
-                        } label: {
-                            Text("완료")
-                                .font(UIFont.systemFont(ofSize: 17, weight: .semibold))
-                                .foregroundStyle(Color(hex: "3478F6") ?? .blue)
-                        }
-                    }
                 }
                 .focused($isKeyBoardOn)
                 .foregroundStyle(.black)
@@ -198,16 +193,14 @@ extension SuccessFailView {
 }
 
 extension SuccessFailView {
-    private func passedFinishedButtonPressed() {
+    private func passedFinishedButtonPressed(success: @escaping () -> Void) {
         if let scholarshipBox {
-            viewModel.susseccButtonPressed(scholarship: scholarshipBox)
+            viewModel.susseccButtonPressed(scholarship: scholarshipBox, success: success)
         }
-        self.isShowPassModal = false
     }
-    private func failedFinishedButtonPressed() {
+    private func failedFinishedButtonPressed(success: @escaping () -> Void) {
         if let scholarshipBox {
-            viewModel.failButtonPressed(scholarship: scholarshipBox)
+            viewModel.failButtonPressed(scholarship: scholarshipBox, success: success)
         }
-        self.isShowPassModal = false
     }
 }

--- a/janghakhere/janghakhere/Feature/MyScholarship/SuccessFailView.swift
+++ b/janghakhere/janghakhere/Feature/MyScholarship/SuccessFailView.swift
@@ -40,27 +40,35 @@ struct SuccessFailView: View {
     }
     
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            navigationView()
-            VStack(alignment: .leading, spacing: 0) {
-                Text("합격 여부를 알려주세요")
-                    .font(.title_md)
-                    .padding(.top, 14)
-                    .padding(.bottom, 60)
-                
-                passButton()
-                failedButton()
-                    .padding(.bottom, 60)
-                if isSelectedPass == .pass {
-                    passedAmmountTextField()
+        ZStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 0) {
+                navigationView()
+                VStack(alignment: .leading, spacing: 0) {
+                    Text("합격 여부를 알려주세요")
+                        .font(.title_md)
+                        .padding(.top, 14)
+                        .padding(.bottom, 60)
+                    
+                    passButton()
+                    failedButton()
+                        .padding(.bottom, 60)
+                    if isSelectedPass == .pass {
+                        passedAmmountTextField()
+                    }
+                    Spacer()
                 }
-                Spacer()
+                if viewModel.isShowSavedError {
+                    ErrorToastView(.network)
+                        .onAppear {
+                            //TODO: ErrorToastView에서 isShowAlert 관리하게 두기...
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                                viewModel.isShowSavedError = false
+                            }
+                        }
+                }
             }
         }
         .paddingHorizontal()
-        .onChange(of: scholarshipBox?.publicAnnouncementStatus) { _,_ in
-            print("scholarshipBox?.publicAnnouncementStatus 바뀜", scholarshipBox?.publicAnnouncementStatus)
-        }
     }
 }
 
@@ -108,6 +116,7 @@ extension SuccessFailView {
                             isShowPassModal = false
                             isChangedToPass()
                         })
+                        isKeyBoardOn = false
                     }
             }
         }

--- a/janghakhere/janghakhere/Feature/MyScholarship/SuccessFailViewModel.swift
+++ b/janghakhere/janghakhere/Feature/MyScholarship/SuccessFailViewModel.swift
@@ -15,26 +15,22 @@ final class SuccessFailViewModel: ObservableObject {
     
     private var tasks: [Task<Void, Never>] = []
     
-    func susseccButtonPressed(scholarship: ScholarshipBox) {
-        self.postScholarshipStatus(id: scholarship.id, status: PublicAnnouncementStatusCategory.passed)
+    func susseccButtonPressed(scholarship: ScholarshipBox, success: @escaping () -> Void) {
+        self.postScholarshipStatus(id: scholarship.id, status: PublicAnnouncementStatusCategory.passed, success: success)
     }
     
-    func failButtonPressed(scholarship: ScholarshipBox) {
-        self.postScholarshipStatus(id: scholarship.id, status: PublicAnnouncementStatusCategory.non_passed)
+    func failButtonPressed(scholarship: ScholarshipBox, success: @escaping () -> Void) {
+        self.postScholarshipStatus(id: scholarship.id, status: PublicAnnouncementStatusCategory.non_passed, success: success)
     }
 }
 
 // private 함수들
 extension SuccessFailViewModel {
-    private func postScholarshipStatus(id: String, status: PublicAnnouncementStatusCategory) {
+    private func postScholarshipStatus(id: String, status: PublicAnnouncementStatusCategory, success: @escaping () -> Void) {
         Task {
             do {
-                let isStatusSuccess = try await sholarshipStatusActor.postScholarshipStatus(id: id, status: status.rawValue)
-                
-                if !isStatusSuccess {
-                    // FIXME: Toast 저장 안 됐음 알리기
-                    isShowSavedError = true
-                }
+                try await sholarshipStatusActor.postScholarshipStatus(id: id, status: status.rawValue)
+                success()
             } catch {
                 isShowSavedError = true
                 print(error)

--- a/janghakhere/janghakhere/Feature/ScholarshipBox/ScholarshipBoxListView.swift
+++ b/janghakhere/janghakhere/Feature/ScholarshipBox/ScholarshipBoxListView.swift
@@ -68,13 +68,20 @@ struct ScholarshipBoxListView: View {
                         }
                         .fullScreenCover(isPresented: $isShowPassModal) {
                             if let selectedScholarship {
-                                SuccessFailView(scholarshipBox: $selectedScholarship, isShowPassModal: $isShowPassModal)
-                                    .onDisappear {
-                                        if let index = scholarshipList.firstIndex(where: { $0.id == selectedScholarship.id }) {
-                                            scholarshipList[index].publicAnnouncementStatus = selectedScholarship.publicAnnouncementStatus
-                                        }
-                                        self.selectedScholarship = nil
+                                SuccessFailView(scholarshipBox: $selectedScholarship, isShowPassModal: $isShowPassModal, isChangedToPass: {
+                                    if let index = scholarshipList.firstIndex(where: { $0.id == selectedScholarship.id }) {
+                                        scholarshipList[index].publicAnnouncementStatus = .passed
+                                        print("ddd passed")
                                     }
+                                }, isChangedToFailed: {
+                                    if let index = scholarshipList.firstIndex(where: { $0.id == selectedScholarship.id }) {
+                                        scholarshipList[index].publicAnnouncementStatus = .non_passed
+                                        print("ddd faild")
+                                    }
+                                })
+                                .onDisappear {
+                                    self.selectedScholarship = nil
+                                }
                             }
                         }
                     }

--- a/janghakhere/janghakhere/Feature/ScholarshipBox/ScholarshipBoxListView.swift
+++ b/janghakhere/janghakhere/Feature/ScholarshipBox/ScholarshipBoxListView.swift
@@ -17,8 +17,6 @@ struct ScholarshipBoxListView: View {
     @Binding var scholarshipList: [ScholarshipBox]
     let boxCategory: BoxCategory
     
-    let isShowPassStatus: Bool
-    
     var body: some View {
         VStack(spacing: 0) {
             ScrollView {
@@ -28,9 +26,8 @@ struct ScholarshipBoxListView: View {
                         Button {
                             pathModel.paths.append(.detailScholarshipView(id: scholarshipList[index].id, status: scholarshipList[index].publicAnnouncementStatus))
                         } label: {
-                            if !isShowPassStatus {
-                                ScholarshipBoxView(scholarshipBox: $scholarshipList[index], category: boxCategory)
-                            } else {
+                            switch boxCategory {
+                            case .MyScholarship:
                                 switch scholarshipList[index].publicAnnouncementStatus {
                                 case  .nothing, .saved, .planned, .non_passed, .passed:
                                     ScholarshipBoxView(scholarshipBox: $scholarshipList[index], category: boxCategory)
@@ -55,6 +52,8 @@ struct ScholarshipBoxListView: View {
                                     }
                                     .background(.white)
                                 }
+                            default:
+                                ScholarshipBoxView(scholarshipBox: $scholarshipList[index], category: boxCategory)
                             }
                         }
                         .cornerRadius(8)

--- a/janghakhere/janghakhere/Feature/ScholarshipBox/ScholarshipBoxListView.swift
+++ b/janghakhere/janghakhere/Feature/ScholarshipBox/ScholarshipBoxListView.swift
@@ -71,12 +71,10 @@ struct ScholarshipBoxListView: View {
                                 SuccessFailView(scholarshipBox: $selectedScholarship, isShowPassModal: $isShowPassModal, isChangedToPass: {
                                     if let index = scholarshipList.firstIndex(where: { $0.id == selectedScholarship.id }) {
                                         scholarshipList[index].publicAnnouncementStatus = .passed
-                                        print("ddd passed")
                                     }
                                 }, isChangedToFailed: {
                                     if let index = scholarshipList.firstIndex(where: { $0.id == selectedScholarship.id }) {
                                         scholarshipList[index].publicAnnouncementStatus = .non_passed
-                                        print("ddd faild")
                                     }
                                 })
                                 .onDisappear {

--- a/janghakhere/janghakhere/Feature/ScholarshipBox/ScholarshipBoxView.swift
+++ b/janghakhere/janghakhere/Feature/ScholarshipBox/ScholarshipBoxView.swift
@@ -100,13 +100,13 @@ extension ScholarshipBoxView {
         .foregroundStyle(scholarshipBox.publicAnnouncementStatus.buttonFontColor)
         .onTapGesture {
             switch category {
-            case .AllScholarship, .SearchScholarship:
+            case .AllScholarship, .SearchScholarship, .MyScholarship:
                 if scholarshipBox.publicAnnouncementStatus == .nothing {
                     viewModel.mainStorageButtonPressed(id: scholarshipBox.id)
                 } else {
                     viewModel.isStatusSheet = true
                 }
-            case .DetailScholarship, .MyScholarship:
+            case .DetailScholarship:
                 viewModel.isStatusSheet = true
             }
         }

--- a/janghakhere/janghakhere/Feature/ScholarshipBox/ScholarshipBoxViewModel.swift
+++ b/janghakhere/janghakhere/Feature/ScholarshipBox/ScholarshipBoxViewModel.swift
@@ -35,17 +35,10 @@ extension ScholarshipBoxViewModel {
     private func postScholarshipStatus(id: String, status: PublicAnnouncementStatusCategory) {
         Task {
             do {
-                async let isStatusSuccess = self.sholarshipStatusActor.postScholarshipStatus(id: id, status: status.rawValue)
-                async let isStoredSuccess = self.sholarshipStatusActor.postScholarshipStatus(id: id, status: "stored")
+                try await sholarshipStatusActor.postScholarshipStatus(id: id, status: status.rawValue)
+                try await sholarshipStatusActor.postScholarshipStatus(id: id, status: "stored")
                 
-                let (success1, success2) = await (try isStatusSuccess, try isStoredSuccess)
-                
-                if success1 && success2 {
-                    changedStatus = status
-                } else {
-                    // FIXME: Toast 저장 안 됐음 알리기
-                    isShowSavedError = true
-                }
+                changedStatus = status
             } catch {
                 isShowSavedError = true
                 print(error)
@@ -56,17 +49,10 @@ extension ScholarshipBoxViewModel {
     private func deleteScholarshipStatus(id: String, status: PublicAnnouncementStatusCategory) {
         Task {
             do {
-                async let isStatusSuccess = self.sholarshipStatusActor.postScholarshipStatus(id: id, status: status.rawValue)
-                async let isStoredSuccess = self.sholarshipStatusActor.deleteScholarshipStatus(id: id)
+                try await sholarshipStatusActor.postScholarshipStatus(id: id, status: status.rawValue)
+                try await sholarshipStatusActor.deleteScholarshipStatus(id: id)
                 
-                let (success1, success2) = await (try isStatusSuccess, try isStoredSuccess)
-                
-                if success1 && success2 {
-                    changedStatus = status
-                } else {
-                    // FIXME: Toast 저장 안 됐음 알리기
-                    isShowSavedError = true
-                }
+                changedStatus = status
             } catch {
                 isShowSavedError = true
                 print(error)


### PR DESCRIPTION
- #53 

합격 API에 수령 금액 추가, 합격 불합격 취소 테스크는 현재 API가 없어서 구현이 완료된 상태가 아닙니다.
그래서 일단 UI 쪽이랑 불합격 버튼 클릭시 반영이 안 됐던 로직 에러 있었던 거 해결했습니다! 