### PR TITLE
[Hotfix] status 바인딩되도록 수정

### DIFF
--- a/janghakhere/janghakhere.xcodeproj/project.pbxproj
+++ b/janghakhere/janghakhere.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 		FBABCF022BD636890068178F /* AlarmActor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBABCEFF2BD636890068178F /* AlarmActor.swift */; };
 		FBABCF032BD636890068178F /* AlarmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBABCF002BD636890068178F /* AlarmView.swift */; };
 		FBABCF042BD636890068178F /* AlarmViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBABCF012BD636890068178F /* AlarmViewModel.swift */; };
+		FBDF58902C0A9F7700C55503 /* ScholarshipStatusViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBDF588D2C0A9F7700C55503 /* ScholarshipStatusViewModel.swift */; };
 		FBE769772BCF7698007F8DEF /* GrayLineTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBE769762BCF7698007F8DEF /* GrayLineTextFieldView.swift */; };
 		FBE769792BCF769E007F8DEF /* MainButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBE769782BCF769E007F8DEF /* MainButtonView.swift */; };
 		FBE7697B2BCF76A4007F8DEF /* GrayBoxGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBE7697A2BCF76A4007F8DEF /* GrayBoxGridView.swift */; };
@@ -224,6 +225,7 @@
 		FBABCEFF2BD636890068178F /* AlarmActor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmActor.swift; sourceTree = "<group>"; };
 		FBABCF002BD636890068178F /* AlarmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmView.swift; sourceTree = "<group>"; };
 		FBABCF012BD636890068178F /* AlarmViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmViewModel.swift; sourceTree = "<group>"; };
+		FBDF588D2C0A9F7700C55503 /* ScholarshipStatusViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ScholarshipStatusViewModel.swift; path = janghakhere/Feature/ScholarshipStatusViewModel.swift; sourceTree = SOURCE_ROOT; };
 		FBE769762BCF7698007F8DEF /* GrayLineTextFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrayLineTextFieldView.swift; sourceTree = "<group>"; };
 		FBE769782BCF769E007F8DEF /* MainButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainButtonView.swift; sourceTree = "<group>"; };
 		FBE7697A2BCF76A4007F8DEF /* GrayBoxGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrayBoxGridView.swift; sourceTree = "<group>"; };
@@ -588,6 +590,7 @@
 		FBEEBB9A2BCEA7C1006CE5EA /* Feature */ = {
 			isa = PBXGroup;
 			children = (
+				FBDF588D2C0A9F7700C55503 /* ScholarshipStatusViewModel.swift */,
 				7BB1E28E2BE6781A001350DE /* TapView */,
 				FB9785F82BE4BDC600F8A281 /* ScholarshipBox */,
 				FB7F97022BE7F4760082F6F4 /* ErrorToastView.swift */,
@@ -825,6 +828,7 @@
 				FB27A2B32BD2ABAC007C62D0 /* UserDefaultKey.swift in Sources */,
 				FBEF1CFC2BE7FC7600DCAA0E /* ScholarshipBoxViewModel.swift in Sources */,
 				FB01DC1D2BE500B20057E37E /* SuccessFailViewModel.swift in Sources */,
+				FBDF58902C0A9F7700C55503 /* ScholarshipStatusViewModel.swift in Sources */,
 				FB27A2B12BD2A933007C62D0 /* ChipsGroupView.swift in Sources */,
 				7B5C11602BDFEADC0056C2BC /* ScholarshipPostingSheet.swift in Sources */,
 				FB7F97032BE7F4760082F6F4 /* ErrorToastView.swift in Sources */,

--- a/janghakhere/janghakhere/App/janghakhereApp.swift
+++ b/janghakhere/janghakhere/App/janghakhereApp.swift
@@ -26,6 +26,7 @@ struct janghakhereApp: App {
     var body: some Scene {
         WindowGroup {
             FirstView()
+                .environmentObject(ScholarshipStatusViewModel())
         }
         .modelContainer(sharedModelContainer)
     }

--- a/janghakhere/janghakhere/Data/Actor/MyScholarshipBoxListActor.swift
+++ b/janghakhere/janghakhere/Data/Actor/MyScholarshipBoxListActor.swift
@@ -32,7 +32,7 @@ actor MyScholarshipBoxListActor {
             case .recent:
                 parameter = "?recent=true"
             }
-//           /api/scholarships/members/{memberId}/stored
+            
             let (data , response) = try await HTTPUtils.getURL(urlBack: "/api/scholarships/members/\(userID)/stored", parameter: parameter)
             
             let scholarshipList = try responseHandling(data, response)

--- a/janghakhere/janghakhere/Feature/AllScholarship/AllScholarshipView.swift
+++ b/janghakhere/janghakhere/Feature/AllScholarship/AllScholarshipView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct AllScholarshipView: View {
     @EnvironmentObject private var pathModel: PathModel
+    @EnvironmentObject private var scholarshipStatusViewModel: ScholarshipStatusViewModel
     @StateObject private var viewModel = AllScholarshipViewModel()
     @State private var isUserSwipedBanner = false
     
@@ -45,6 +46,9 @@ struct AllScholarshipView: View {
         }
         .onAppear {
             viewModel.viewOpened()
+            let newScholarShipList = scholarshipStatusViewModel.getFilteringScholarshipList(list: viewModel.scholarshipList)
+            viewModel.scholarshipList = newScholarShipList
+            print("viewModel.scholarshipList", viewModel.scholarshipList)
             NotificationManager.instance.requestAuthorization()
         }
         .onDisappear {

--- a/janghakhere/janghakhere/Feature/AllScholarship/AllScholarshipViewModel.swift
+++ b/janghakhere/janghakhere/Feature/AllScholarship/AllScholarshipViewModel.swift
@@ -162,8 +162,6 @@ extension AllScholarshipViewModel {
 // 기본 함수들
 extension AllScholarshipViewModel {
     func viewOpened() {
-        self.scholarshipList = []
-        self.nextPageNumber = 0
         self.getScholarShipList(scholarshipCategory)
         self.timerinit()
         self.initializeUserData()

--- a/janghakhere/janghakhere/Feature/AllScholarship/Search/SearchScholarshipView.swift
+++ b/janghakhere/janghakhere/Feature/AllScholarship/Search/SearchScholarshipView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct SearchScholarshipView: View {
     @EnvironmentObject private var pathModel: PathModel
+    @EnvironmentObject private var scholarshipStatusViewModel: ScholarshipStatusViewModel
     @Environment(\.dismiss) private var dismiss
     @StateObject private var viewModel = SearchScholarshipViewModel()
     @FocusState private var isKeyBoardOn: Bool
@@ -38,6 +39,8 @@ struct SearchScholarshipView: View {
         .background(.gray50)
         .onAppear {
             isKeyBoardOn = true
+            let newScholarShipList = scholarshipStatusViewModel.getFilteringScholarshipList(list: viewModel.scholarshipList)
+            viewModel.scholarshipList = newScholarShipList
             viewModel.viewOpened()
         }
         .onDisappear {

--- a/janghakhere/janghakhere/Feature/DetailScholarship/DetailScholarshipView.swift
+++ b/janghakhere/janghakhere/Feature/DetailScholarship/DetailScholarshipView.swift
@@ -9,16 +9,18 @@ import SwiftUI
 import TipKit
 
 struct DetailScholarshipView: View {
-    @EnvironmentObject private var pathModel: PathModel
     @Environment(\.dismiss) private var dismiss
-    let id: String
-    let status: PublicAnnouncementStatusCategory
+    
+    @EnvironmentObject private var pathModel: PathModel
+    @EnvironmentObject private var scholarshipStatusViewModel: ScholarshipStatusViewModel
     
     @StateObject private var viewModel = DetailScholarshipViewModel()
     @State private var showApplication: Bool = true
     @State private var showSelection: Bool = true
     @State private var showRequirement: Bool = true
     
+    let id: String
+    let status: PublicAnnouncementStatusCategory
     let scholarshipBoxViewModel = ScholarshipBoxViewModel()
     private let effortLevelTip = EffortLevelTip()
     
@@ -104,7 +106,9 @@ extension DetailScholarshipView {
             .sheet(isPresented: $viewModel.isStatusSheet) {
                 ScholarshipPostingSheet(category: $viewModel.status, statusButtonPressed: { category in
                     if let detailContent = viewModel.detailContent {
-                        scholarshipBoxViewModel.sheetStorageButtonPressed(id: String(detailContent.id), status: category)
+                        scholarshipBoxViewModel.sheetStorageButtonPressed(id: String(detailContent.id), status: category) {
+                                scholarshipStatusViewModel.addScholarship(id: String(detailContent.id), status: category)
+                        }
                     }
                     viewModel.isStatusSheet = false
                 })

--- a/janghakhere/janghakhere/Feature/MyScholarship/MyScholarshipView.swift
+++ b/janghakhere/janghakhere/Feature/MyScholarship/MyScholarshipView.swift
@@ -11,6 +11,7 @@ struct MyScholarshipView: View {
     @EnvironmentObject private var pathModel: PathModel
     @Environment(\.dismiss) private var dismiss
     @StateObject private var viewModel = MyScholarshipViewModel()
+    @EnvironmentObject private var scholarshipStatusViewModel: ScholarshipStatusViewModel
     
     var body: some View {
         VStack(spacing: 0) {
@@ -40,9 +41,13 @@ struct MyScholarshipView: View {
             if let category = viewModel.getStoreChangedtScholarShip() {
                 viewModel.scholarshipCategoryButtonPressed(category)
             }
+            let newScholarShipList = scholarshipStatusViewModel.getFilteringScholarshipList(list: viewModel.selectedScholarShipList)
+            viewModel.selectedScholarShipList = newScholarShipList
         })
         .onAppear {
             viewModel.viewOpened()
+            let newScholarShipList = scholarshipStatusViewModel.getFilteringScholarshipList(list: viewModel.totalScholarShipList)
+            viewModel.totalScholarShipList = newScholarShipList
         }
         .onDisappear {
             viewModel.cancelTasks()

--- a/janghakhere/janghakhere/Feature/MyScholarship/SuccessFailView.swift
+++ b/janghakhere/janghakhere/Feature/MyScholarship/SuccessFailView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct SuccessFailView: View {
+    @EnvironmentObject private var scholarshipStatusViewModel: ScholarshipStatusViewModel
+    
     @StateObject var viewModel: SuccessFailViewModel = SuccessFailViewModel()
     
     @Binding var scholarshipBox: ScholarshipBox?
@@ -113,6 +115,7 @@ extension SuccessFailView {
                     .onTapGesture {
                         passedFinishedButtonPressed(success: {
                             scholarshipBox!.publicAnnouncementStatus = .passed
+                            scholarshipStatusViewModel.addScholarship(id: scholarshipBox!.id, status: .passed)
                             isShowPassModal = false
                             isChangedToPass()
                         })
@@ -148,6 +151,7 @@ extension SuccessFailView {
             isSelectedPass = .failed
             failedFinishedButtonPressed {
                 scholarshipBox!.publicAnnouncementStatus = .non_passed
+                scholarshipStatusViewModel.addScholarship(id: scholarshipBox!.id, status: .non_passed)
                 isShowPassModal = false
                 isChangedToFailed()
             }

--- a/janghakhere/janghakhere/Feature/ScholarshipBox/ScholarshipBoxView.swift
+++ b/janghakhere/janghakhere/Feature/ScholarshipBox/ScholarshipBoxView.swift
@@ -16,6 +16,7 @@ enum BoxCategory {
 
 struct ScholarshipBoxView: View {
     @EnvironmentObject private var pathModel: PathModel
+    @EnvironmentObject private var scholarshipStatusViewModel: ScholarshipStatusViewModel
     
     @Binding var scholarshipBox: ScholarshipBox
     @StateObject var viewModel: ScholarshipBoxViewModel = ScholarshipBoxViewModel()
@@ -102,7 +103,9 @@ extension ScholarshipBoxView {
             switch category {
             case .AllScholarship, .SearchScholarship, .MyScholarship:
                 if scholarshipBox.publicAnnouncementStatus == .nothing {
-                    viewModel.mainStorageButtonPressed(id: scholarshipBox.id)
+                    viewModel.mainStorageButtonPressed(id: scholarshipBox.id) {
+                        scholarshipStatusViewModel.addScholarship(id: scholarshipBox.id, status: .saved)
+                    }
                 } else {
                     viewModel.isStatusSheet = true
                 }
@@ -112,7 +115,9 @@ extension ScholarshipBoxView {
         }
         .sheet(isPresented: $viewModel.isStatusSheet) {
             ScholarshipPostingSheet(category: $scholarshipBox.publicAnnouncementStatus, statusButtonPressed: { category in
-                viewModel.sheetStorageButtonPressed(id: scholarshipBox.id, status: category)
+                viewModel.sheetStorageButtonPressed(id: scholarshipBox.id, status: category) {
+                    scholarshipStatusViewModel.addScholarship(id: scholarshipBox.id, status: category)
+                }
                 viewModel.isStatusSheet = false
             })
         }

--- a/janghakhere/janghakhere/Feature/ScholarshipBox/ScholarshipBoxViewModel.swift
+++ b/janghakhere/janghakhere/Feature/ScholarshipBox/ScholarshipBoxViewModel.swift
@@ -16,29 +16,30 @@ final class ScholarshipBoxViewModel: ObservableObject {
     @Published var isShowSavedError: Bool = true
     
     /// 맞춤, 전체 공고에 있는 저장 버튼 클릭시
-    func mainStorageButtonPressed(id: String) {
-        postScholarshipStatus(id: id, status: PublicAnnouncementStatusCategory.saved)
+    func mainStorageButtonPressed(id: String, afterAddingStatus: @escaping () -> Void) {
+        postScholarshipStatus(id: id, status: PublicAnnouncementStatusCategory.saved, afterAddingStatus: afterAddingStatus)
     }
     
     /// 시트에서  공고 status 변경 버튼을 클릭 시
-    func sheetStorageButtonPressed(id: String, status: PublicAnnouncementStatusCategory) {
+    func sheetStorageButtonPressed(id: String, status: PublicAnnouncementStatusCategory, afterAddingStatus: @escaping () -> Void) {
         if status == .nothing {
-            deleteScholarshipStatus(id: id, status: status)
+            deleteScholarshipStatus(id: id, status: status, afterAddingStatus: afterAddingStatus)
         } else {
-            postScholarshipStatus(id: id, status: status)
+            postScholarshipStatus(id: id, status: status, afterAddingStatus: afterAddingStatus)
         }
     }
 }
 
 // private 함수들
 extension ScholarshipBoxViewModel {
-    private func postScholarshipStatus(id: String, status: PublicAnnouncementStatusCategory) {
+    private func postScholarshipStatus(id: String, status: PublicAnnouncementStatusCategory, afterAddingStatus: @escaping () -> Void) {
         Task {
             do {
                 try await sholarshipStatusActor.postScholarshipStatus(id: id, status: status.rawValue)
                 try await sholarshipStatusActor.postScholarshipStatus(id: id, status: "stored")
                 
                 changedStatus = status
+                afterAddingStatus()
             } catch {
                 isShowSavedError = true
                 print(error)
@@ -46,13 +47,14 @@ extension ScholarshipBoxViewModel {
         }
     }
     
-    private func deleteScholarshipStatus(id: String, status: PublicAnnouncementStatusCategory) {
+    private func deleteScholarshipStatus(id: String, status: PublicAnnouncementStatusCategory, afterAddingStatus: @escaping () -> Void) {
         Task {
             do {
                 try await sholarshipStatusActor.postScholarshipStatus(id: id, status: status.rawValue)
                 try await sholarshipStatusActor.deleteScholarshipStatus(id: id)
                 
                 changedStatus = status
+                afterAddingStatus()
             } catch {
                 isShowSavedError = true
                 print(error)

--- a/janghakhere/janghakhere/Feature/ScholarshipStatusViewModel.swift
+++ b/janghakhere/janghakhere/Feature/ScholarshipStatusViewModel.swift
@@ -1,0 +1,33 @@
+//
+//  ScholarshipStatusViewModel.swift
+//  janghakhere
+//
+//  Created by Gaeun Lee on 6/1/24.
+//
+
+import SwiftUI
+
+@MainActor
+final class ScholarshipStatusViewModel: ObservableObject {
+    @Published private(set) var ScholarshipStatusList: [String : PublicAnnouncementStatusCategory] = [:]
+}
+
+// MARK: - private 함수들
+extension ScholarshipStatusViewModel {
+    
+    // ScholarshipStatusList에 status가 변경된 ScholarshipBox 저장
+    func addScholarship(id: String, status: PublicAnnouncementStatusCategory) {
+        ScholarshipStatusList[id] = status
+    }
+    
+    ///[ScholarshipBox]을 요소로 받아서 현재 status 값이 변경된 장학금들 [ScholarshipBox]에 반영해서 return하기
+    func getFilteringScholarshipList(list: [ScholarshipBox]) -> [ScholarshipBox] {
+        var returnList = list
+        for index in list.indices {
+            if let status = ScholarshipStatusList[list[index].id] {
+                returnList[index].publicAnnouncementStatus = status
+            }
+        }
+        return returnList
+    }
+}


### PR DESCRIPTION
## [기존에 있었던 문제]
- 장학금 Status가 변경될 시 모든 View에서 사용되고 있는 장학금의 status도 동시에 반영이 되어야 한다는 문제
<table> 
        <tr>
           <td><img width="250" alt="스크린샷 2024-06-01 오전 9 49 36" src="https://github.com/rriver2/Mollatjanghak/assets/82457928/d975c138-318d-49ae-a257-97dc1a35cacd"></td>
           <td><img width="250" alt="스크린샷 2024-06-01 오전 9 48 43" src="https://github.com/rriver2/Mollatjanghak/assets/82457928/184e5c74-291c-43fc-a80d-f2cde58083fe"></td>
           <td><img width="250" alt="스크린샷 2024-06-01 오전 9 48 18" src="https://github.com/rriver2/Mollatjanghak/assets/82457928/2d0fa351-a5f8-451a-b5fe-44d12f756613"></td>
           <td><img width="250" alt="스크린샷 2024-06-01 오전 9 48 11" src="https://github.com/rriver2/Mollatjanghak/assets/82457928/9e4d7d7a-6e4c-4ada-a925-32c65a07546e"></td>
        </tr>
</table> 

## [해결방법]
저번에는 빠른 배포를 위해서 API를 재요청을 시켰었었습니다.
-> 이럴 경우 발생하는 문제
1. 불필요한 API 재요청 (로직적인 오버헤드)
2. View가 reload되면서 제일 위의 장학금으로 스크롤업 (UX적인 불편함)

따라서 EnvironmentObject를 활용해서 문제를 해결했습니다
1) 어떤 View에서 장학금 Status를 변경하는 API를 요청하고, 성공할 시 `ScholarshipStatusViewModel` 의 
`ScholarshipStatusList`에 그 장학금의 id와 status를 dictionary 형태로 저장해둡니다.
2) 어떤 View가 OnAppear될 때 ScholarshipStatusViewModel의 ScholarshipStatusList를 확인해서 해당 ViewModel에 같은 장학금 id가 있을 시에 status를 ScholarshipStatusList에 있는 최신 Status로 변경합니다.
<img width="583" alt="스크린샷 2024-06-01 오전 9 58 59" src="https://github.com/rriver2/Mollatjanghak/assets/82457928/0fe14846-f9b1-4ea1-b55a-ce95d5ba94d5">

## [느낀점]
1) ViewModel을 잘 묶어놔서 Actor 2개에만 해당 코드를 수정하면 됐어서 뿌듯했습니다.
2) Success, Failed 시 호출되는 함수를 @escaping func로 했는데, Result를 활용해서 리팩토링하는 게 깔끔할 것 같다는.. 생각이 들었습니다.
3) 그리고 SwiftUI View Cycle 공부를 해서 공유하도록 하겠습니다. 제가 그간 OnAppear을 오해하고 있었던 부분이 있던 것 같더라구요..